### PR TITLE
Fix indentmini causing nvim hang

### DIFF
--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -33,8 +33,18 @@ local function indentline(hl_current)
     local hi_name = hl_group(indent)
 
     ctx[row] = indent
+     
+    local function indent_step()                                                                                                           
+      if vim.fn.exists('*shiftwidth') ~= 0 then
+        return vim.fn.shiftwidth()
+      elseif vim.fn.exists('+shiftwidth') ~= 0 then
+        return vim.opt_local.shiftwidth
+      end
+    end
 
-    for i = 1, indent - 1, vim.fn.shiftwidth() do
+    local shift_step = indent_step()
+
+    for i = 1, indent - 1, shift_step do
       if col_in_screen(i - 1) then
         local param, col = {}, 0
         if #text == 0 and i - 1 > 0 then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -34,7 +34,7 @@ local function indentline(hl_current)
 
     ctx[row] = indent
 
-    for i = 1, indent - 1, vim.bo[bufnr].sw do
+    for i = 1, indent - 1, vim.fn.shiftwidth() do
       if col_in_screen(i - 1) then
         local param, col = {}, 0
         if #text == 0 and i - 1 > 0 then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -33,12 +33,19 @@ local function indentline(hl_current)
     local hi_name = hl_group(indent)
 
     ctx[row] = indent
-     
-    local function indent_step()                                                                                                           
+
+    local function indent_step()
       if vim.fn.exists('*shiftwidth') ~= 0 then
         return vim.fn.shiftwidth()
       elseif vim.fn.exists('+shiftwidth') ~= 0 then
-        return vim.opt_local.shiftwidth
+        -- sample impl of shiftwidth builtin
+        if vim.opt_local.shiftwidth:get() ~= 0 then
+          return vim.opt_local.shiftwidth:get()
+        elseif vim.opt_local.tabstop:get() ~= 0 then
+          return vim.opt_local.tabstop:get()
+        else
+          return 8
+        end
       end
     end
 

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -35,10 +35,10 @@ local function indentline(hl_current)
     ctx[row] = indent
 
     local function indent_step()
-      if vim.fn.exists('*shiftwidth') ~= 0 then
+      if vim.fn.exists('*shiftwidth') == 1 then
         return vim.fn.shiftwidth()
-      elseif vim.fn.exists('+shiftwidth') ~= 0 then
-        -- sample impl of shiftwidth builtin
+      elseif vim.fn.exists('&shiftwidth') == 1 then
+        -- impl of shiftwidth builtin
         if vim.opt_local.shiftwidth:get() ~= 0 then
           return vim.opt_local.shiftwidth:get()
         elseif vim.opt_local.tabstop:get() ~= 0 then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -38,13 +38,11 @@ local function indentline(hl_current)
       if vim.fn.exists('*shiftwidth') == 1 then
         return vim.fn.shiftwidth()
       elseif vim.fn.exists('&shiftwidth') == 1 then
-        -- impl of shiftwidth builtin
-        if vim.opt_local.shiftwidth:get() ~= 0 then
-          return vim.opt_local.shiftwidth:get()
-        elseif vim.opt_local.tabstop:get() ~= 0 then
-          return vim.opt_local.tabstop:get()
-        else
-          return 8
+        -- implementation of shiftwidth builtin
+        if vim.bo[bufnr].shiftwidth ~= 0 then
+          return vim.bo[bufnr].shiftwidth
+        elseif vim.bo[bufnr].tabstop ~= 0 then
+          return vim.bo[bufnr].tabstop
         end
       end
     end


### PR DESCRIPTION
Fix issue #4, indentmini causing nvim hang due to access to a buffer-local option in a loop

use `vim.fn.shiftwidth()` in place of `vim.bo[bufnr].sw`