### PR TITLE
Add multi-color indent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ require('lazy').setup({
 
 - char     -- string type default is  `│`,
 - exclude  -- table  type add exclude filetype in this table
-- hi_group -- table  type highlight groups to use
-
-highlight groups for indentation markers are created automatically by passing in a list
-of groups. Indentation colors will appear in the order they are passed in.
 
 ```lua
 config = function()
@@ -32,15 +28,55 @@ config = function()
             "erlang",
             "markdown",
         }
-        hi_group = {
-            'Comment',
-            'Function',
-            'Constant',
-            'MyIndentation'
-        }
     })
-    vim.cmd.highlight('MyIndentation guifg=#32a852')
+
+    -- Colors are applied automatically based on user-defined highlight groups.
+    -- There is no default value.
+    vim.cmd.highlight('IndentLine1 guifg=#123456')
+    vim.cmd([[highlight IndentLine2 guifg=#123456]])
 end,
+```
+
+## Recipies
+
+By default, if you switch colorschemes your indent colors will be cleared out.
+To fix this, create an autocommand that will set them again on change. You can
+also set it up with different colors per-scheme if you'd like.
+
+```lua
+    config = function()
+    -- create a function to set the colors
+      local setColors = function()
+        local hi_colors = {
+          'guifg=#AD7021',
+          'guifg=#8887C3',
+          'guifg=#738A05',
+          'guifg=#5F819D',
+          'guifg=#9E8FB2',
+          'guifg=#907AA9',
+          'guifg=#CDA869',
+          'guifg=#8F9D6A',
+        }
+
+        -- you could add some logic here to conditionally set the
+        -- highlight colors based on what scheme you're switching to.
+
+        for i, val in pairs(hi_colors) do
+          vim.cmd.highlight('IndentLine' .. i .. ' ' .. val)
+        end
+      end
+
+      -- set up an autocommand to set the colors when the colorscheme changes
+      vim.api.nvim_create_autocmd('ColorScheme', {
+        pattern = '*',
+        callback = setColors,
+      })
+
+      -- don't forget to call it on startup!  
+      setColors()
+
+      require('indentmini').setup()
+    end,
 ```
 
 ## License MIT

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ require('lazy').setup({
 
 ## Config
 
-- char    -- string type default is  `│`,
-- exclude -- table  type add exclude filetype in this table
+- char     -- string type default is  `│`,
+- exclude  -- table  type add exclude filetype in this table
+- hi_group -- table  type highlight groups to use
 
-highlight group is `IndentLine`. you can use this to link it to `Comment`
+highlight groups for indentation markers are created automatically by passing in a list
+of groups. Indentation colors will appear in the order they are passed in.
 
 ```lua
 config = function()
@@ -30,9 +32,14 @@ config = function()
             "erlang",
             "markdown",
         }
+        hi_group = {
+            'Comment',
+            'Function',
+            'Constant',
+            'MyIndentation'
+        }
     })
-    -- use comment color
-    vim.cmd.highlight("default link IndentLine Comment")
+    vim.cmd.highlight('MyIndentation guifg=#32a852')
 end,
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ config = function()
 
     -- Colors are applied automatically based on user-defined highlight groups.
     -- There is no default value.
-    vim.cmd.highlight('IndentLine1 guifg=#123456')
-    vim.cmd([[highlight IndentLine2 guifg=#123456]])
+    vim.cmd.highlight('IndentLine guifg=#123456')
 end,
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,21 +47,21 @@ also set it up with different colors per-scheme if you'd like.
     -- create a function to set the colors
       local setColors = function()
         local hi_colors = {
-          'guifg=#AD7021',
-          'guifg=#8887C3',
-          'guifg=#738A05',
-          'guifg=#5F819D',
-          'guifg=#9E8FB2',
-          'guifg=#907AA9',
-          'guifg=#CDA869',
-          'guifg=#8F9D6A',
+          '#AD7021',
+          '#8887C3',
+          '#738A05',
+          '#5F819D',
+          '#9E8FB2',
+          '#907AA9',
+          '#CDA869',
+          '#8F9D6A',
         }
 
         -- you could add some logic here to conditionally set the
         -- highlight colors based on what scheme you're switching to.
 
         for i, val in pairs(hi_colors) do
-          vim.cmd.highlight('IndentLine' .. i .. ' ' .. val)
+          vim.api.nvim_set_hl(0, 'IndentLine' .. i, { fg = val })
         end
       end
 

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -49,7 +49,7 @@ local function indentline()
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
       print(iteration, (iteration + 1) % 6)
-      hi_name = string.format('%s%d', hi_name, iteration)
+      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or iteration % 6)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -49,7 +49,8 @@ local function indentline()
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
       print(iteration, iteration % 6)
-      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or iteration % 6)
+      local it = iteration % 6
+      hi_name = string.format('%s%d', hi_name, it == 0 and 1 or it)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -9,6 +9,19 @@ local function col_in_screen(col)
   return col >= leftcol
 end
 
+local hl_groups = {}
+local all_highlights = vim.api.nvim_exec('highlight', true)
+for _, line in ipairs(vim.split(all_highlights, '\n')) do
+  local imhl = string.match(line, 'IndentLine%d+')
+  if imhl then
+    if hl_groups[imhl] then
+      break
+    else
+      table.insert(hl_groups, imhl)
+    end
+  end
+end
+
 local function indent_step(bufnr)
   if vim.fn.exists('*shiftwidth') == 1 then
     return vim.fn.shiftwidth()
@@ -43,19 +56,6 @@ local function indentline()
     end
 
     ctx[row] = indent
-
-    local hl_groups = {}
-    local all_highlights = vim.api.nvim_exec('highlight', true)
-    for _, line in ipairs(vim.split(all_highlights, '\n')) do
-      local imhl = string.match(line, 'IndentLine%d+')
-      if imhl then
-        if hl_groups[imhl] then
-          break
-        else
-          table.insert(hl_groups, imhl)
-        end
-      end
-    end
 
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,9 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      local it = iteration % 7
-      hi_name = string.format('%s%d', hi_name, it + 1)
-      print(iteration, it, hi_name)
+      hi_name = string.format('%s%d', hi_name, iteration % 6 + 1)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,8 +48,8 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      print(iteration, (iteration + 1) % 6)
-      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or (iteration + 1) % 6)
+      print(iteration, iteration % 6)
+      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or iteration % 6)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,7 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      hi_name = string.format('%s%d', hi_name, iteration % 6 + 1)
+      hi_name = string.format('%s%d', hi_name, (iteration - 1) % 6 + 1)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -49,7 +49,7 @@ local function indentline()
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
       print(iteration, (iteration + 1) % 6)
-      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or iteration % 6)
+      hi_name = string.format('%s%d', hi_name, iteration == 0 and 1 or (iteration + 1) % 6)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -12,7 +12,7 @@ end
 local hl_groups = {}
 local all_highlights = vim.api.nvim_exec('highlight', true)
 for _, line in ipairs(vim.split(all_highlights, '\n')) do
-  local imhl = string.match(line, 'IndentLine%d+')
+  local imhl = string.match(line, 'IndentLine(%d?).+')
   if imhl then
     if hl_groups[imhl] then
       break

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -9,8 +9,16 @@ local function col_in_screen(col)
   return col >= leftcol
 end
 
-local function hl_group()
-  return 'IndentLine'
+local function hl_group(num)
+  local hl_groups = {
+    'IndentLine1',
+    'IndentLine2',
+    'IndentLine3',
+    'IndentLine4',
+    'IndentLine5',
+    'IndentLine6',
+  }
+  return hl_groups[num]
 end
 
 local function indent_step(bufnr)
@@ -46,11 +54,10 @@ local function indentline()
       indent = prev > 20 and 4 or prev
     end
 
-    local hi_name = hl_group()
-
     ctx[row] = indent
 
     for i = 1, indent - 1, indent_step(bufnr) do
+      local hi_name = hl_group(math.fmod(i, 7))
       if col_in_screen(i - 1) then
         local param, col = {}, 0
         if #text == 0 and i - 1 > 0 then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -9,17 +9,6 @@ local function col_in_screen(col)
   return col >= leftcol
 end
 
-local function hl_group(hi_colors, shiftw, index)
-  local hi_name = 'IndentLine'
-  if #hi_colors ~= 0 then
-    local iteration = math.floor((index - 1) / shiftw) + 1
-    local idx = (iteration - 1) % #hi_colors + 1
-    hi_name = string.format('%s%d', hi_name, iteration)
-
-    vim.cmd.highlight('default link ' .. hi_name .. ' ' .. hi_colors[idx])
-  end
-end
-
 local function indent_step(bufnr)
   if vim.fn.exists('*shiftwidth') == 1 then
     return vim.fn.shiftwidth()
@@ -57,7 +46,14 @@ local function indentline(opts)
 
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
-      local hi_name = hl_group(opts.hi_colors, shiftw, i)
+      local hi_name = 'IndentLine'
+      if #opts.hi_colors ~= 0 then
+        local iteration = math.floor((i - 1) / shiftw) + 1
+        local idx = (iteration - 1) % #opts.hi_colors + 1
+        hi_name = string.format('%s%d', hi_name, iteration)
+
+        vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
+      end
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,6 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
+      print(iteration, iteration % 6)
       hi_name = string.format('%s%d', hi_name, iteration)
 
       if col_in_screen(i - 1) then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,7 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      print(iteration, iteration % 6)
+      print(iteration, (iteration + 1) % 6)
       hi_name = string.format('%s%d', hi_name, iteration)
 
       if col_in_screen(i - 1) then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -49,7 +49,7 @@ local function indentline()
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
       local it = iteration % 7
-      hi_name = string.format('%s%d', hi_name, it == 0 and 1 or it)
+      hi_name = string.format('%s%d', hi_name, it + 1)
       print(iteration, it, hi_name)
 
       if col_in_screen(i - 1) then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -47,13 +47,13 @@ local function indentline(opts)
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
-      if opts.hi_colors and #opts.hi_colors ~= 0 then
-        local iteration = math.floor((i - 1) / shiftw) + 1
-        local idx = (iteration - 1) % #opts.hi_colors + 1
-        hi_name = string.format('%s%d', hi_name, iteration)
+      -- if opts.hi_colors and #opts.hi_colors ~= 0 then
+      local iteration = math.floor((i - 1) / shiftw) + 1
+      -- local idx = (iteration - 1) % #opts.hi_colors + 1
+      hi_name = string.format('%s%d', hi_name, iteration)
 
-        vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
-      end
+      -- vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
+      -- end
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -49,8 +49,8 @@ local function indentline()
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
       local it = iteration % 7
-      print(iteration, it)
       hi_name = string.format('%s%d', hi_name, it == 0 and 1 or it)
+      print(iteration, it, hi_name)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,7 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      hi_name = string.format('%s%d', hi_name, (iteration - 1) % 6 + 1)
+      hi_name = string.format('%s%d', hi_name, (iteration - 1) % 5 + 1)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -44,11 +44,24 @@ local function indentline()
 
     ctx[row] = indent
 
+    local hl_groups = {}
+    local all_highlights = vim.api.nvim_exec('highlight', true)
+    for _, line in ipairs(vim.split(all_highlights, '\n')) do
+      local imhl = string.match(line, 'IndentLine%d+')
+      if imhl then
+        if hl_groups[imhl] then
+          break
+        else
+          table.insert(hl_groups, imhl)
+        end
+      end
+    end
+
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      hi_name = string.format('%s%d', hi_name, (iteration - 1) % 5 + 1)
+      hi_name = string.format('%s%d', hi_name, (iteration - 1) % #hl_groups + 1)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -9,19 +9,6 @@ local function col_in_screen(col)
   return col >= leftcol
 end
 
-local hl_groups = {}
-local all_highlights = vim.api.nvim_exec('highlight', true)
-for _, line in ipairs(vim.split(all_highlights, '\n')) do
-  local imhl = string.match(line, 'IndentLine(%d?).+')
-  if imhl then
-    if hl_groups[imhl] then
-      break
-    else
-      table.insert(hl_groups, imhl)
-    end
-  end
-end
-
 local function indent_step(bufnr)
   if vim.fn.exists('*shiftwidth') == 1 then
     return vim.fn.shiftwidth()
@@ -58,10 +45,27 @@ local function indentline()
     ctx[row] = indent
 
     local shiftw = indent_step(bufnr)
+    local last_defined_level = 0
     for i = 1, indent - 1, shiftw do
-      local hi_name = 'IndentLine'
-      local iteration = math.floor((i - 1) / shiftw) + 1
-      hi_name = string.format('%s%d', hi_name, (iteration - 1) % #hl_groups + 1)
+      local indent_level = math.floor((i - 1) / shiftw) + 1
+      local hi_name = ('IndentLine%d'):format(indent_level)
+      -- Attempt to fetch highlight details for the current level
+      local hl_details = api.nvim_get_hl(0, { name = hi_name })
+
+      -- If no custom highlight details are found, use the last defined level for looping back
+      if next(hl_details) == nil then
+        if last_defined_level > 0 then
+          local looped_level = ((indent_level - 1) % last_defined_level) + 1
+          hi_name = ('IndentLine%d'):format(looped_level)
+        else
+          -- If no last_defined_level is set yet, just set it as the current one
+          last_defined_level = indent_level
+        end
+      else
+        -- If highlight details are found, update last_defined_level
+        last_defined_level = indent_level
+      end
+      api.nvim_set_hl(0, hi_name, { link = 'IndentLine', default = true })
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,7 +48,7 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      local it = iteration % 5
+      local it = iteration % 7
       print(iteration, it)
       hi_name = string.format('%s%d', hi_name, it == 0 and 1 or it)
 

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,8 +48,8 @@ local function indentline()
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
       local iteration = math.floor((i - 1) / shiftw) + 1
-      print(iteration, iteration % 6)
-      local it = iteration % 6
+      local it = iteration % 5
+      print(iteration, it)
       hi_name = string.format('%s%d', hi_name, it == 0 and 1 or it)
 
       if col_in_screen(i - 1) then

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -58,6 +58,7 @@ local function indentline()
           local looped_level = ((indent_level - 1) % last_defined_level) + 1
           hi_name = ('IndentLine%d'):format(looped_level)
         else
+          hi_name = 'IndentLine'
           -- If no last_defined_level is set yet, just set it as the current one
           last_defined_level = indent_level
         end

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -9,6 +9,17 @@ local function col_in_screen(col)
   return col >= leftcol
 end
 
+local function hl_group(hi_colors, shiftw, index)
+  local hi_name = 'IndentLine'
+  if #hi_colors ~= 0 then
+    local iteration = math.floor((index - 1) / shiftw) + 1
+    local idx = (iteration - 1) % #hi_colors + 1
+    hi_name = string.format('%s%d', hi_name, iteration)
+
+    vim.cmd.highlight('default link ' .. hi_name .. ' ' .. hi_colors[idx])
+  end
+end
+
 local function indent_step(bufnr)
   if vim.fn.exists('*shiftwidth') == 1 then
     return vim.fn.shiftwidth()
@@ -46,14 +57,7 @@ local function indentline(opts)
 
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
-      local hi_name = 'IndentLine'
-      if #opts.hi_colors ~= 0 then
-        local iteration = math.floor((i - 1) / shiftw) + 1
-        local idx = (iteration - 1) % #opts.hi_colors + 1
-        hi_name = string.format('%s%d', hi_name, iteration)
-
-        vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
-      end
+      local hi_name = hl_group(opts.hi_colors, shiftw, i)
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -47,12 +47,12 @@ local function indentline(opts)
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
-      if #opts.hl_colors ~= 0 then
+      if #opts.hi_colors ~= 0 then
         local iteration = math.floor((i - 1) / shiftw) + 1
-        local idx = (iteration - 1) % #opts.hl_colors + 1
+        local idx = (iteration - 1) % #opts.hi_colors + 1
         hi_name = string.format('%s%d', hi_name, iteration)
 
-        vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hl_colors[idx])
+        vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
       end
 
       if col_in_screen(i - 1) then
@@ -118,7 +118,7 @@ local function setup(opt)
   nvim_create_autocmd('BufEnter', {
     group = group,
     callback = function()
-      indentline({ hl_colors = opt.hl_colors })
+      indentline({ hi_colors = opt.hi_colors })
     end,
   })
 end

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -22,7 +22,7 @@ local function indent_step(bufnr)
   end
 end
 
-local function indentline(opts)
+local function indentline()
   local function on_win(_, _, bufnr, _)
     if bufnr ~= vim.api.nvim_get_current_buf() then
       return false
@@ -47,13 +47,8 @@ local function indentline(opts)
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
-      -- if opts.hi_colors and #opts.hi_colors ~= 0 then
       local iteration = math.floor((i - 1) / shiftw) + 1
-      -- local idx = (iteration - 1) % #opts.hi_colors + 1
       hi_name = string.format('%s%d', hi_name, iteration)
-
-      -- vim.cmd.highlight('default link ' .. hi_name .. ' ' .. opts.hi_colors[idx])
-      -- end
 
       if col_in_screen(i - 1) then
         local param, col = {}, 0
@@ -118,7 +113,7 @@ local function setup(opt)
   nvim_create_autocmd('BufEnter', {
     group = group,
     callback = function()
-      indentline({ hi_colors = opt.hi_colors })
+      indentline()
     end,
   })
 end

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -47,7 +47,7 @@ local function indentline(opts)
     local shiftw = indent_step(bufnr)
     for i = 1, indent - 1, shiftw do
       local hi_name = 'IndentLine'
-      if #opts.hi_colors ~= 0 then
+      if opts.hi_colors and #opts.hi_colors ~= 0 then
         local iteration = math.floor((i - 1) / shiftw) + 1
         local idx = (iteration - 1) % #opts.hi_colors + 1
         hi_name = string.format('%s%d', hi_name, iteration)


### PR DESCRIPTION
Hi, I was just integrating this into my config and wanted the same thing that was mentioned in #3, I figured out a couple ways to do it, I like this one the best since it's more extensible. 

This allows you to pass in a table of as many highlight groups as you want and it will set them for each indent column automatically.

<details>
<summary>Example ➡️ </summary>

```lua
  use({
    'KingEdwardI/indentmini.nvim',
    branch = 'multi-color-indents',
    config = function()
      local setColors = function()
        local hi_colors = {
          'guifg=#AD7021',
          'guifg=#8887C3',
          'guifg=#738A05',
          'guifg=#5F819D',
          'guifg=#9E8FB2',
          'guifg=#907AA9',
          'guifg=#CDA869',
          'guifg=#8F9D6A',
        }

        for i, val in pairs(hi_colors) do
          vim.cmd.highlight('IndentLine' .. i .. ' ' .. val)
        end
      end
      vim.api.nvim_create_autocmd('ColorScheme', {
        pattern = '*',
        callback = setColors,
      })
      setColors()

      require('indentmini').setup()
    end,
  })
```

![Screen Shot 2024-02-22 at 7 48 41 PM](https://github.com/nvimdev/indentmini.nvim/assets/20171781/f68836b1-7a6b-447c-be64-dc1188a5fc6f)

</details>

Let me know what you think and if I should make any updates. Great plugin, thanks!