### PR TITLE
Fix blinking lines when cursor line is enabled

### DIFF
--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -22,7 +22,7 @@ local function indent_step(bufnr)
   end
 end
 
-local function indentline()
+local function indentline(group)
   local function on_win(_, _, bufnr, _)
     if bufnr ~= vim.api.nvim_get_current_buf() then
       return false
@@ -30,6 +30,12 @@ local function indentline()
   end
 
   local ctx = {}
+  vim.api.nvim_create_autocmd('BufDelete', {
+    group = group,
+    callback = function()
+      ctx = {}
+    end,
+  })
   local function on_line(_, _, bufnr, row)
     local indent = vim.fn.indent(row + 1)
     local ok, lines = pcall(api.nvim_buf_get_text, bufnr, row, 0, row, -1, {})
@@ -93,10 +99,6 @@ local function indentline()
     end
   end
 
-  local function on_end()
-    ctx = {}
-  end
-
   local function on_start(_, _)
     local bufnr = api.nvim_get_current_buf()
     local exclude_buftype = { 'nofile', 'terminal' }
@@ -113,7 +115,6 @@ local function indentline()
     on_win = on_win,
     on_start = on_start,
     on_line = on_line,
-    on_end = on_end,
   })
 end
 
@@ -131,7 +132,7 @@ local function setup(opt)
   nvim_create_autocmd('BufEnter', {
     group = group,
     callback = function()
-      indentline()
+      indentline(group)
     end,
   })
 end


### PR DESCRIPTION
Hi and thanks for the plugin. I noticed that there is a blinking effect when passing empty lines while smaming "j". However, this only reproduces when `cursorline` is set

Steps to repro
- install plugin
- call `require('indentmini').setup()`
- enable cursor line `:set cursorline`
- press `j` multiple times for the cursor to pass an empty line surrounded by indented non empty lines

<details><summary>Before demo</summary>

https://github.com/nvimdev/indentmini.nvim/assets/5817809/a4b1921a-6c4d-464a-b945-ddd88783041b

</details>

The way I understood it, this happens because ctx is emptied after every tick in the `on_end` function. Which in turn defaults previous line to 0 inside `on_line`

https://github.com/nvimdev/indentmini.nvim/blob/b18d7168e59dbe8700649e2d58022432d8fde2e2/lua/indentmini/init.lua#L40

I have tried looking up the indent level of a previous line by recursively walking up the lines until the first non empty line but that did not 

A simple workaround would be to not empty the context. This of course can come at some memory consumption price. To ease it I added an autocommand that would empty the context once a buffer is closed.

<details><summary>After demo</summary>

https://github.com/nvimdev/indentmini.nvim/assets/5817809/82bb6333-44c1-4e39-be23-3a391697d9e9

</details>

Hope this helps
