### PR TITLE
Implement performance improvements

### DIFF
--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -48,8 +48,8 @@ local function col_in_screen(col)
   return col >= vim.fn.winsaveview().leftcol
 end
 
-local function non_or_space(row, col)
-  local text = api.nvim_buf_get_text(0, row, col, row, col + 1, {})[1]
+local function non_or_space(line, col)
+  local text = line:sub(col, col)
   return text and (#text == 0 or text == ' ') or false
 end
 
@@ -110,7 +110,7 @@ local function on_line(_, _, bufnr, row)
     if row > cache.reg_srow and row < cache.reg_erow and level == cache.cur_inlevel then
       higroup = 'IndentLineCurrent'
     end
-    if col_in_screen(col) and non_or_space(row, col) then
+    if col_in_screen(col) and non_or_space(line, col) then
       opt.config.virt_text[1][2] = higroup
       if line_is_empty and col > 0 then
         opt.config.virt_text_win_col = i - 1


### PR DESCRIPTION
This PR introduces the performance improvements discussed in #14 plus some more caching not mentioned there. In summary (from oldest to newest commit):

1. Check if the indents should be calculated in `on_win()` instead of `on_line()`  - once per window not once per line
2. Calculate the current line range in `on_win()` instead of `on_line()` - once per window not once per line
3. Prefer `nvim_buf_get_lines()` over `nvim_buf_get_text()` for entire lines as is mentioned in the docs. Not sure if this improves performance.
4. Get the line contents once per line not once per indent level
5. Cache some calls to the api, so they are not recomputed multiple times per line
6. The `non_or_space()` does not need to compare chars because `indent()` returns the number of leading spaces. I'm not 100% sure about this one, but it seems to work.
7. Cache length and `indent()` of each line. Not sure if this is necessary.

I have not done any extensive testing, just checked a few different files and they looked alright. Also I don't know how to profile a plugin's performance, so I don't know by how much if at all each of these changes help.