### PR TITLE
fix: current indent highlight

### DIFF
--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -251,7 +251,7 @@ local function on_line(_, _, bufnr, row)
   -- 1 1 2  2  3  3
   local total = context.mixup and math.ceil(sp.indent / context.tabstop) or sp.indent - 1
   local step = context.mixup and 1 or context.step
-  local higroup = 'IndentLine'
+  local higroup = 'Normal'
   for i = 1, total, step do
     local col = i - 1
     local level = context.mixup and i or math.floor(col / context.step) + 1
@@ -267,9 +267,13 @@ local function on_line(_, _, bufnr, row)
     then
       local row_in_curblock = context.range_srow
         and (row > context.range_srow and row < context.range_erow)
-      if opt.only_current and row_in_curblock and level == context.cur_inlevel then
+
+      if row_in_curblock and level == context.cur_inlevel then
         higroup = 'IndentLineCurrent'
+      elseif not opt.only_current then
+        higroup = 'IndentLine'
       end
+
       opt.config.virt_text[1][2] = higroup
       if sp.is_empty and col > 0 then
         opt.config.virt_text_win_col = not context.mixup and i - 1 - context.leftcol


### PR DESCRIPTION
Fixes an issue that came up after [0ab6a35](https://github.com/nvimdev/indentmini.nvim/commit/0ab6a35333637dec65590990dc588e4d034c0870)
when only_current option was set to `false`, current indent highlight stopped working.