### PR TITLE
Improve level detection, allow disabling in specific TreeSitter classes, add toggle functionality and lazy-loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,40 @@ available config values in setup table.
 - minlevel -- number the min level that show indent line default is 1
 - only_current -- boolean default is false when true will only highlight current range
 - exclude_nodetype -- table with TS classes where guides are not drawn, defaults to `{ 'string', 'comment' }`
+- key -- string, hotkey to toggle the indent guides. Not set by default.
+- enabled -- boolean, controls the default state of the plugin
 
 ```lua
 config = function()
     require("indentmini").setup() -- use default config
 end,
+```
+
+## Toggle Functionality
+
+You can toggle indent guides via:
+
+### Commands
+
+- `:IndentToggle` - Toggle indent guides on/off
+- `:IndentEnable` - Enable indent guides
+- `:IndentDisable` - Disable indent guides
+
+### Hotkey
+
+```lua
+require("indentmini").setup({
+    key = '<F5>',
+})
+```
+
+### API
+
+```lua
+local indentmini = require("indentmini")
+indentmini.toggle()
+indentmini.enable()
+indentmini.disable()
 ```
 
 ## Highlight

--- a/README.md
+++ b/README.md
@@ -1,35 +1,45 @@
 # indentmini.nvim
 
-An indentation plugin born for the pursuit of **minimal**(~120 lines), **speed**(blazing fastest on files with tens of thousands of lines) and **stability**.
-It renders in the neovim screen redraw circle and will never make your neovim slow.
+An indentation plugin born for the pursuit of minimalism, speed and stability.
+It renders in the NeoVim screen redraw circle and should keep the NeoVim fast.
 
 ![indentmini](https://github.com/nvimdev/indentmini.nvim/assets/41671631/99fb6dd4-8e61-412f-aa4c-c83ee7ce3206)
 
 ## Install
 
-install with any plugin management or default vim package.
+Install with any plugin manager or as a NeoVim package.
 
-## Config
+## Configuration
 
-available config values in setup table.
+| Key              | Description                                   | Default                   |
+|------------------|-----------------------------------------------|---------------------------|
+| char             | Character to draw the indentation guides      | `<BAR>`                   |
+| enabled          | Default state of the plugin                   | `true`                    |
+| exclude          | Disable in these filetypes                    | `{}`                      |
+| exclude_nodetype | TreeSitter classes where guides are not drawn | `{ 'string', 'comment' }` |
+| key              | Hotkey to toggle the guides                   | `''`                      |
+| minlevel         | Minimum level where indentation is drawn      | `0`                       |
+| only_current     | only highlight current indentation level      | `false`                   |
 
-- char     -- string type default is `│`,
-- exclude  -- table  type add exclude filetype in this table ie `{ 'markdown', 'xxx'}`
-- minlevel -- number the min level that show indent line default is 1
-- only_current -- boolean default is false when true will only highlight current range
-- exclude_nodetype -- table with TS classes where guides are not drawn, defaults to `{ 'string', 'comment' }`
-- key -- string, hotkey to toggle the indent guides. Not set by default.
-- enabled -- boolean, controls the default state of the plugin
+### Example
 
 ```lua
 config = function()
-    require("indentmini").setup() -- use default config
-end,
+    require("indentmini").setup({
+        only_current = false,
+        enabled = false,
+        char = '▏',
+        minlevel = 2,
+        key = '<F5>',
+        exclude = { 'markdown', 'help', 'text', 'rst' },
+        exclude_nodetype = { 'string', 'comment' }
+    })
+end
 ```
 
-## Toggle Functionality
+## Toggle functionality
 
-You can toggle indent guides via:
+You can toggle the guides via:
 
 ### Commands
 
@@ -54,17 +64,15 @@ indentmini.enable()
 indentmini.disable()
 ```
 
-## Highlight
+## Colours
 
-if your colorscheme not config the `IndentLine*` relate highlight group you should config it in
-your neovim config.
+The plugin uses `IndentLine*` highlight groups and provides no default values.
 
 ```lua
--- Colors are applied automatically based on user-defined highlight groups.
--- There is no default value.
 vim.cmd.highlight('IndentLine guifg=#123456')
--- Current indent line highlight
 vim.cmd.highlight('IndentLineCurrent guifg=#123456')
 ```
 
-## License MIT
+## Licence
+
+MIT

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ available config values in setup table.
 - exclude  -- table  type add exclude filetype in this table ie `{ 'markdown', 'xxx'}`
 - minlevel -- number the min level that show indent line default is 1
 - only_current -- boolean default is false when true will only highlight current range
+- exclude_nodetype -- table with TS classes where guides are not drawn, defaults to `{ 'string', 'comment' }`
 
 ```lua
 config = function()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # indentmini.nvim
 
-An indentation plugin born for the pursuit of minimalism, speed and stability.
+An indentation plugin born for the pursuit of minimalism, speed and stability.<br>
 It renders in the NeoVim screen redraw circle and should keep the NeoVim fast.
-
-![indentmini](https://github.com/nvimdev/indentmini.nvim/assets/41671631/99fb6dd4-8e61-412f-aa4c-c83ee7ce3206)
 
 ## Install
 
@@ -41,13 +39,13 @@ end
 
 You can toggle the guides via:
 
-### Commands
+#### Commands
 
 - `:IndentToggle` - Toggle indent guides on/off
 - `:IndentEnable` - Enable indent guides
 - `:IndentDisable` - Disable indent guides
 
-### Hotkey
+#### Hotkey
 
 ```lua
 require("indentmini").setup({
@@ -55,7 +53,7 @@ require("indentmini").setup({
 })
 ```
 
-### API
+#### API
 
 ```lua
 local indentmini = require("indentmini")

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Install with any plugin manager or as a NeoVim package.
 
 ### Example
 
+The plugin supports lazy-loading:
+
 ```lua
+cmd = { 'IndentToggle', 'IndentEnable', 'IndentDisable' },
 config = function()
     require("indentmini").setup({
         only_current = false,

--- a/README.md
+++ b/README.md
@@ -24,18 +24,29 @@ Install with any plugin manager or as a NeoVim package.
 The plugin supports lazy-loading:
 
 ```lua
-cmd = { 'IndentToggle', 'IndentEnable', 'IndentDisable' },
-config = function()
-    require("indentmini").setup({
-        only_current = false,
-        enabled = false,
-        char = '▏',
-        minlevel = 2,
-        key = '<F5>',
-        exclude = { 'markdown', 'help', 'text', 'rst' },
-        exclude_nodetype = { 'string', 'comment' }
-    })
-end
+-- Either declare `vim.g.indentmini_key` before you load the plugin:
+vim.g.indentmini_key = '<F5>'
+
+-- or use your plugin manager, for example Lazy.nvim:
+{
+    url = 'https://github.com/nvimdev/indentmini.nvim',
+    cmd = { 'IndentToggle', 'IndentEnable', 'IndentDisable' },
+    keys = {
+        {'<F5>', '<Cmd>IndentToggle<CR>', desc = 'Toggle indent guides'},
+    },
+    lazy = true,
+    config = function()
+        require("indentmini").setup({
+            only_current = false,
+            enabled = false,
+            char = '▏',
+            key = '<F5>', -- optional, can be set here if you don't lazy-load
+            minlevel = 2,
+            exclude = { 'markdown', 'help', 'text', 'rst' },
+            exclude_nodetype = { 'string', 'comment' }
+        })
+    end
+}
 ```
 
 ## Toggle functionality
@@ -50,6 +61,12 @@ You can toggle the guides via:
 
 #### Hotkey
 
+For lazy-loading setups, set the global variable before the plugin loads:
+```lua
+vim.g.indentmini_key = '<F5>'
+```
+
+For non-lazy setups, use the `key` option in `setup()`:
 ```lua
 require("indentmini").setup({
     key = '<F5>',

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -316,17 +316,26 @@ local M = {}
 
 function M.toggle()
   enabled = not enabled
-  vim.cmd('redraw!')
+  vim.api.nvim__redraw({
+      buf = vim.api.nvim_get_current_buf(),
+      valid = false
+  })
 end
 
 function M.enable()
   enabled = true
-  vim.cmd('redraw!')
+  vim.api.nvim__redraw({
+      buf = vim.api.nvim_get_current_buf(),
+      valid = false
+  })
 end
 
 function M.disable()
   enabled = false
-  vim.cmd('redraw!')
+  vim.api.nvim__redraw({
+      buf = vim.api.nvim_get_current_buf(),
+      valid = false
+  })
 end
 
 --- @param conf table|nil IndentMini config

--- a/lua/indentmini/init.lua
+++ b/lua/indentmini/init.lua
@@ -349,18 +349,6 @@ function M.setup(conf)
   opt.minlevel = conf.minlevel or 1
   set_provider(ns, { on_win = on_win, on_line = on_line })
 
-  vim.api.nvim_create_user_command('IndentToggle', function()
-    M.toggle()
-  end, { desc = 'Toggle indent guides' })
-
-  vim.api.nvim_create_user_command('IndentEnable', function()
-    M.enable()
-  end, { desc = 'Enable indent guides' })
-
-  vim.api.nvim_create_user_command('IndentDisable', function()
-    M.disable()
-  end, { desc = 'Disable indent guides' })
-
   if conf.key then
     vim.keymap.set('n', conf.key, '<Cmd>IndentToggle<CR>', {
       desc = 'Toggle indent guides',

--- a/plugin/indentmini.lua
+++ b/plugin/indentmini.lua
@@ -15,3 +15,11 @@ vim.api.nvim_create_user_command(
     function() require('indentmini').disable() end,
     { desc = 'Disable indent guides' }
 )
+
+if vim.g.indentmini_key then
+    vim.keymap.set('n', vim.g.indentmini_key, '<Cmd>IndentToggle<CR>', {
+        desc = 'Toggle indent guides',
+        noremap = true,
+        silent = true,
+    })
+end

--- a/plugin/indentmini.lua
+++ b/plugin/indentmini.lua
@@ -1,0 +1,17 @@
+vim.api.nvim_create_user_command(
+    'IndentToggle',
+    function() require('indentmini').toggle() end,
+    { desc = 'Toggle indent guides' }
+)
+
+vim.api.nvim_create_user_command(
+    'IndentEnable',
+    function() require('indentmini').enable() end,
+    { desc = 'Enable indent guides' }
+)
+
+vim.api.nvim_create_user_command(
+    'IndentDisable',
+    function() require('indentmini').disable() end,
+    { desc = 'Disable indent guides' }
+)


### PR DESCRIPTION
### Features

#### Lazy-loading
Works, tested with `Lazy.nvim`

#### Indent level detection
Hack-ish, but works. The `line_text:find()` seems to be unavoidable.

#### Disable in docstrings
Works, unsurprisingly relies on TS.

#### Enable/Disable/Toggle
Works reliably.

### Changes

- `exclude_nodetype` config option which defaults to `{ 'string', 'comment' }` 
- `enabled` config option to control the default state.
- `key` option to control the toggle.
- Optional `vim.g.indentmini_key` to define a toggle hotkey.
- Massaged the Readme to make it slightly more presentable.

### Issues

Close https://github.com/nvimdev/indentmini.nvim/issues/36
Close https://github.com/nvimdev/indentmini.nvim/issues/39
Close https://github.com/nvimdev/indentmini.nvim/issues/20